### PR TITLE
Add glass chat UI with streaming support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ChainDocs Chat</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="/static/chat.js" defer></script>
+</head>
+<body class="min-h-screen bg-gradient-radial from-black via-gray-900 to-indigo-950 flex items-center justify-center p-4 text-white">
+  <div class="w-full max-w-2xl">
+    <div class="backdrop-blur-md bg-white/10 ring-1 ring-indigo-500/40 rounded-2xl shadow-xl p-6 flex flex-col space-y-4">
+      <div id="chat" class="space-y-4 overflow-y-auto max-h-[70vh]"></div>
+      <form id="chat-form" class="flex space-x-2" hx-post="/ask">
+        <input id="message" name="message" type="text" placeholder="Ask anything..." class="flex-grow bg-transparent border border-indigo-500/40 rounded-xl px-4 py-2 text-white placeholder-indigo-300 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+        <button type="submit" class="px-4 py-2 bg-blue-500 hover:bg-blue-400 text-white font-semibold rounded-xl shadow-[0_0_8px_#3b82f6]">Send</button>
+      </form>
+    </div>
+  </div>
+</body>
+</html>

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,0 +1,53 @@
+const form = document.getElementById('chat-form');
+const input = document.getElementById('message');
+const chat = document.getElementById('chat');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const text = input.value.trim();
+  if (!text) return;
+
+  // Append user message
+  appendMessage('user', text);
+  input.value = '';
+
+  // Placeholder for assistant response
+  const assistantEl = appendMessage('assistant', '');
+
+  // Stream response from server
+  const response = await fetch('/ask', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: text })
+  });
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    assistantEl.innerHTML = marked.parse(buffer);
+    chat.scrollTop = chat.scrollHeight;
+  }
+});
+
+function appendMessage(role, content) {
+  const wrapper = document.createElement('div');
+  if (role === 'user') {
+    wrapper.className = 'text-right';
+  }
+  const bubble = document.createElement('div');
+  if (role === 'user') {
+    bubble.className = 'inline-block bg-indigo-600 text-white px-4 py-2 rounded-xl';
+    bubble.textContent = content;
+  } else {
+    bubble.className = 'prose prose-invert';
+    bubble.innerHTML = content;
+  }
+  wrapper.appendChild(bubble);
+  chat.appendChild(wrapper);
+  chat.scrollTop = chat.scrollHeight;
+  return bubble;
+}


### PR DESCRIPTION
## Summary
- Create full-viewport Tailwind index page with radial gradient and glass chat card.
- Add streaming chat script that posts to `/ask` and renders markdown responses.

## Testing
- `python -m py_compile crawler.py main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689514905f4c832e906adc0f847e04b2