### PR TITLE
Add simple CLI to query ChainDocs API

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,38 @@
+import argparse
+import requests
+
+DEFAULT_HOST = "http://localhost:8000"
+
+
+def color(text: str, code: str) -> str:
+    """Return text string wrapped in ANSI color codes."""
+    return f"\033[{code}m{text}\033[0m"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Query the ChainDocs API via the /ask endpoint"
+    )
+    parser.add_argument("query", help="Question to send to the API")
+    parser.add_argument(
+        "--host",
+        default=DEFAULT_HOST,
+        help="Base URL for the ChainDocs API (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    try:
+        response = requests.get(f"{args.host}/ask", params={"question": args.query})
+        response.raise_for_status()
+        data = response.json()
+        answer = data.get("answer", "")
+        context = data.get("context", "")
+        print(color("Answer:", "1;32"), answer)
+        print(color("Context:", "1;34"), context)
+    except Exception as exc:  # broad catch to surface connection errors nicely
+        print(color("Error:", "1;31"), exc)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ langchain==0.2.17
 llama-cpp-python==0.2.90
 python-dotenv==1.0.1
 pytest==8.3.5
+
+requests==2.32.3


### PR DESCRIPTION
## Summary
- add `cli` module for calling the `/ask` endpoint and colorizing response
- include `requests` in dependencies

## Testing
- `python -m cli "another test"`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689519e1975c832e859a8aaf219dbb70