### PR TITLE
Fix Render start command to serve chat UI

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,5 @@
+services:
+  - type: web
+    name: chaindocs
+    env: python
+    startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
## Summary
- add render.yaml specifying uvicorn start command

## Testing
- `python -m py_compile main.py`
- `curl https://chaindocs.onrender.com/ -L`

------
https://chatgpt.com/codex/tasks/task_e_68953699b934832e966188bbaba54e47