### PR TITLE
Configure Render start command for uvicorn

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: chaindocs
+    env: python
+    rootDir: .
+    buildCommand: "pip install -r requirements.txt"
+    startCommand: "uvicorn main:app --host 0.0.0.0 --port $PORT"


### PR DESCRIPTION
## Summary
- add `render.yaml` to run `uvicorn main:app` and install dependencies on Render

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689537ccc20c832e86029f2cb9108023