### PR TITLE
Use absolute paths for static assets

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,12 +19,15 @@ from pydantic import BaseModel
 from qdrant_client import QdrantClient
 from sentence_transformers import SentenceTransformer
 from llama_cpp import Llama
+from pathlib import Path
 
 # --------------------------------------------------------------------------- #
 #  Init FastAPI app & static hosting
 # --------------------------------------------------------------------------- #
+ROOT = Path(__file__).resolve().parent
+
 app = FastAPI()
-app.mount("/static", StaticFiles(directory="static"), name="static")
+app.mount("/static", StaticFiles(directory=ROOT / "static"), name="static")
 
 # --------------------------------------------------------------------------- #
 #  Global models / clients
@@ -58,7 +61,7 @@ class AskResponse(BaseModel):
 @app.get("/")
 async def spa() -> FileResponse:
     """Serve the HTML chat UI."""
-    return FileResponse("index.html")
+    return FileResponse(ROOT / "index.html")
 
 
 @app.post("/ask", response_model=AskResponse)


### PR DESCRIPTION
## Summary
- derive project root via `Path` for resilient path handling
- mount static files and serve index using the resolved root directory

## Testing
- `python -m py_compile main.py`
- `pytest -q`
- `uvicorn main:app --port 8000` & `curl http://127.0.0.1:8000/ | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_689537d74cd0832eaff759a6dc4cd1a9