### PR TITLE
docs: add render deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Chaindocs
+
+## Deployment
+
+Deploying to [Render](https://render.com/):
+
+- **Root Directory**: `chaindocs`
+- **Build Command**: `pip install -r requirements.txt`
+- **Start Command**: `uvicorn main:app --host 0.0.0.0 --port $PORT`
+


### PR DESCRIPTION
## Summary
- add Render deployment instructions, including root directory, build, and start commands

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689537dd5e7c832ea80b12b3e1594300