### PR TITLE
Gracefully handle missing Qdrant configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@ Deploying to [Render](https://render.com/):
 - **Build Command**: `pip install -r requirements.txt`
 - **Start Command**: `uvicorn main:app --host 0.0.0.0 --port $PORT`
 
+## Environment Variables
+
+The API expects a Qdrant vector database for retrieval. Configure it with:
+
+- `QDRANT_URL` – URL of your Qdrant service.
+- `QDRANT_API_KEY` – API key for that service.
+- `QDRANT_COLLECTION` – collection name (defaults to `chaindocs`).
+
+Leaving `QDRANT_URL` or `QDRANT_API_KEY` unset will disable Qdrant integration; in
+that case the `/ask` endpoint responds with an error indicating the missing
+configuration. This can be useful for local development.
+


### PR DESCRIPTION
## Summary
- validate Qdrant environment variables before creating a client
- return informative error from `/ask` when Qdrant is not configured
- document Qdrant-related environment variables

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68957c9f9c04832e8443f120af732aa7