### PR TITLE
Clean render.yaml configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,17 +1,8 @@
+---
 services:
   - type: web
     name: chaindocs
     env: python
- codex/verify-deployment-and-run-command
-    startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT
-
- codex/update-deployment-settings-for-service
+    rootDir: .
     buildCommand: pip install -r requirements.txt
     startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT
-    rootDir: .
-
-    rootDir: .
-    buildCommand: "pip install -r requirements.txt"
-    startCommand: "uvicorn main:app --host 0.0.0.0 --port $PORT"
- main
- main


### PR DESCRIPTION
## Summary
- tidy render.yaml by removing non-YAML codex lines and duplicates
- keep a single buildCommand, startCommand, and rootDir for the web service

## Testing
- `yamllint render.yaml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689587f1d0dc832e9bcd5b38ed558ff0