### PR TITLE
Check response status and sanitize answers

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <script src="https://unpkg.com/htmx.org@1.9.12"></script>
   <!-- Markdown renderer for answers -->
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
 
   <style>
     html,body{height:100%}

--- a/static/chat.js
+++ b/static/chat.js
@@ -20,8 +20,14 @@ form.addEventListener('submit', async (e) => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query: text })
     });
-    const data = await response.json();
-    assistantEl.innerHTML = marked.parse(data.answer || '');
+    if (response.ok) {
+      const data = await response.json();
+      assistantEl.innerHTML = DOMPurify.sanitize(
+        marked.parse(data.answer || '')
+      );
+    } else {
+      assistantEl.textContent = `Error: ${response.status} ${response.statusText}`;
+    }
   } catch (err) {
     assistantEl.textContent = 'Error fetching response.';
   }


### PR DESCRIPTION
## Summary
- Add DOMPurify CDN script so markdown answers are sanitized before rendering
- Check `response.ok` and show HTTP status on failures before parsing JSON, sanitizing any received content

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689587f64508832e8b4974c8ccdc6688