### PR TITLE
Make health status message configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The API expects a Qdrant vector database for retrieval. Configure it with:
 - `QDRANT_URL` – URL of your Qdrant service.
 - `QDRANT_API_KEY` – API key for that service.
 - `QDRANT_COLLECTION` – collection name (defaults to `chaindocs`).
+- `HEALTH_STATUS_MSG` – message returned by `/health` (defaults to `ChainDocs API is alive!`).
 
 Leaving `QDRANT_URL` or `QDRANT_API_KEY` unset will disable Qdrant integration; in
 that case the `/ask` endpoint responds with an error indicating the missing

--- a/main.py
+++ b/main.py
@@ -162,10 +162,13 @@ async def ask(req: Request):
     return JSONResponse({"answer": answer, "sources": sources})
 
 
+HEALTH_STATUS_MSG = os.getenv("HEALTH_STATUS_MSG", "ChainDocs API is alive!")
+
+
 @app.get("/health")
 def health():
     return {
-        "status": "ChainDocs API is alive!",
+        "status": HEALTH_STATUS_MSG,
         "embedder": EMBED_MODEL_NAME,
         "qdrant_configured": bool(qdrant),
         "collection": QDRANT_COLLECTION,


### PR DESCRIPTION
## Summary
- read health status text from `HEALTH_STATUS_MSG` env var with default fallback
- document `HEALTH_STATUS_MSG` in setup instructions

## Testing
- `python -m py_compile main.py`
- `pytest`
- `uvicorn main:app --port 8001 --host 0.0.0.0` + `curl http://localhost:8001/health`


------
https://chatgpt.com/codex/tasks/task_e_689590367b74832eacd78418ae6da600